### PR TITLE
feat(name): Allow to redefine error name property

### DIFF
--- a/src/custom-error.spec.ts
+++ b/src/custom-error.spec.ts
@@ -43,6 +43,20 @@ test('Extended with constructor', () => {
 	})
 })
 
+test('Extended with name', () => {
+	class RenamedError extends CustomError {
+		constructor(name: string, message?: string) {
+			super(message)
+			Object.defineProperty(this, 'name', { value: name });
+		}
+	}
+	checkProtoChain(RenamedError, CustomError, Error)
+	checkProperties(new RenamedError('test', 'test message'), {
+		name: 'test',
+		message: 'test message',
+	})
+})
+
 test('Basic properties', () =>
 	checkProperties(new CustomError('my message'), {
 		name: 'CustomError',
@@ -55,5 +69,5 @@ test('Without message', () =>
 		message: '',
 	}))
 
-test('native log behaviour', () =>
+test('Native log behaviour', () =>
 	expect(`${new CustomError('Hello')}`).toMatch('CustomError: Hello'))

--- a/src/custom-error.ts
+++ b/src/custom-error.ts
@@ -28,6 +28,7 @@ export class CustomError extends Error {
 		Object.defineProperty(this, 'name', {
 			value: new.target.name,
 			enumerable: false,
+			configurable: true,
 		})
 		// fix the extended error prototype chain
 		// because typescript __extends implementation can't

--- a/src/factory.spec.ts
+++ b/src/factory.spec.ts
@@ -35,9 +35,19 @@ test('Factory extended by class', () => {
 	checkProtoChain(SubError, TestError, RangeError, Error)
 })
 
+test('Factory extended with name', () => {
+	const RenamedError = customErrorFactory(function RenamedError(this: RangeError, message: string) {
+		this.message = message
+		Object.defineProperty(this, 'name', { value: 'test' });
+	}, RangeError) as ErrorConstructor
+	checkProtoChain(RenamedError, RangeError, Error)
+	checkProperties(new RenamedError('test message'), {
+		name: 'test',
+		message: 'test message',
+	})
+})
+
 test('Factory properties', () => {
-
-
 	function TestError(this: Props, code = 1, message = 'foo') {
 		this.code = code
 		this.message = message
@@ -86,7 +96,7 @@ test('Factory properties', () => {
 	})
 })
 
-test('native log behaviour', () =>
+test('Native log behaviour', () =>
 	expect(`${customErrorFactory(function TestError(this: Props, message) {
 		this.message = message
 	})('Hello')}`).toMatch('TestError: Hello'))

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -48,10 +48,14 @@ export function customErrorFactory<Properties>(
 		if (!(this instanceof CustomError)) return new CustomError(...args)
 		// apply super
 		parent.apply(this, args)
+		// set name from custom fn, default to parent Error name
+		Object.defineProperty(this, 'name', {
+			value: fn.name || parent.name,
+			enumerable: false,
+			configurable: true,
+		})
 		// apply custom fn
 		fn.apply(this, args)
-		// set name from custom fn, default to parent Error name
-		this.name = fn.name || parent.name
 		// try to remove contructor from stack trace
 		fixStack(this, CustomError)
 	}


### PR DESCRIPTION
make cutom error name property configurable

fix # 53