### PR TITLE
fix: update types to support TS 4.8.2

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -39,7 +39,7 @@ type CustomErrorFunction<Properties> = (this: Properties, ...args: any[]) => voi
  * new HttpError(404, 'Not found')
  * ```
  */
-export function customErrorFactory<Properties>(
+export function customErrorFactory<Properties extends CustomErrorProperties>(
 	fn: CustomErrorFunction<Properties>,
 	parent: GenericErrorConstructor = Error,
 ) {


### PR DESCRIPTION
This PR doesn't bump TS, but it at least makes sure it will build with [TS 4.8.2](https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/).

This is currently preventing me from using the lib along with TS 4.8.2 in my own projects.