### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   coverage:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/adriengibrat/ts-custom-error/security/code-scanning/1](https://github.com/adriengibrat/ts-custom-error/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or the specific job. Since there is only one job shown ("coverage"), it’s simplest and clearest to add the `permissions` block at the job level immediately before `runs-on:`. For most coverage and publishing actions, `contents: read` is sufficient unless an action requires broader access. Since the codeclimate-action only uploads to external services and does not write to the repository, `contents: read` is the minimal starting point. No new imports or plugin installations are needed; just a modification to the YAML file to add the block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
