### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/adriengibrat/ts-custom-error/security/code-scanning/2](https://github.com/adriengibrat/ts-custom-error/security/code-scanning/2)

To fix the problem, we should explicitly set the `permissions` key in the workflow or in the specific job. The most minimal and widely recommended starting point is `permissions: contents: read`, which grants read-only access to repository contents. Since the workflow includes a `semantic-release` step, which creates GitHub releases (and may need to update tags and release notes), the workflow will require `contents: write` for that step. Therefore, we can set a default of `contents: read` at the workflow level, and then override permissions to `contents: write` for the `build` job or only for the step that needs it (if the action or step supports per-step permission overrides). 

GitHub currently only supports job-level granularity, so the appropriate least-privilege fix is to set `permissions: contents: read` at the workflow or job level, and if `semantic-release` needs to create releases/tags, grant `contents: write` (and possibly `issues: write` and/or `pull-requests: write` if required) at the job level.

To be strictly minimal and compatible, set at least `contents: write` for the `build` job, and explain how further restriction could be done if more analysis on `semantic-release` needs are performed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
